### PR TITLE
chore: .npmrc に min-release-age=2880 を設定

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=2880


### PR DESCRIPTION
## 概要
`.npmrc` を追加し、`min-release-age=2880`（2日）を設定しました。

## 変更内容
- ルートに `.npmrc` を新規追加
- `min-release-age=2880` を設定

## 補足
- 設定追加のみのため、テストは未実施です。
