### PR TITLE
Dependabot の更新を multi-ecosystem グループにまとめる

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,31 @@
 version: 2
+
+multi-ecosystem-groups:
+  dependency-updates:
+    schedule:
+      interval: "weekly"
+
 updates:
   - package-ecosystem: "npm"
     directory: "/"
-    schedule:
-      interval: "weekly"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "dependency-updates"
     cooldown:
       default-days: 2
+    groups:
+      all-npm-security-updates:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "dependency-updates"
+    groups:
+      all-docker-security-updates:
+        applies-to: "security-updates"
+        patterns:
+          - "*"


### PR DESCRIPTION
### Motivation
- Dependabot による複数の依存更新PRを可能な限り1つのグループにまとめてレビュー負荷を下げるため。 
- npm と Docker の更新を同一の週次スケジュールで扱い、関連するセキュリティ更新もグルーピングできるようにするため。

### Description
- `.github/dependabot.yml` に `multi-ecosystem-groups.dependency-updates` を追加してスケジュールを週次に移動した。 
- npm エントリを `patterns: ['*']` と `multi-ecosystem-group: 'dependency-updates'` に変更し、既存の `cooldown.default-days: 2` は維持した。 
- Docker 用の更新エントリを追加して同じ `dependency-updates` グループに割り当て、npm と Docker それぞれに `applies-to: "security-updates"` のワイルドカードグループを追加した。

### Testing
- `ruby -e 'require "yaml"; data = YAML.load_file(".github/dependabot.yml"); abort("bad version") unless data["version"] == 2; abort("missing multi-ecosystem-groups") unless data.dig("multi-ecosystem-groups", "dependency-updates", "schedule", "interval") == "weekly"; updates = data["updates"]; abort("bad updates") unless updates.is_a?(Array) && updates.size == 2; abort("missing npm group") unless updates.any? { |u| u["package-ecosystem"] == "npm" && u["patterns"] == ["*"] && u["multi-ecosystem-group"] == "dependency-updates" && u.dig("groups", "all-npm-security-updates", "applies-to") == "security-updates" }; abort("missing docker group") unless updates.any? { |u| u["package-ecosystem"] == "docker" && u["patterns"] == ["*"] && u["multi-ecosystem-group"] == "dependency-updates" && u.dig("groups", "all-docker-security-updates", "applies-to") == "security-updates" }; puts "dependabot.yml is valid YAML and grouping is configured"'` を実行して設定検証が成功した。 
- `git diff --check` を実行して差分チェックに問題がないことを確認した。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01b896b63c8326b4adf9e00a5d7630)