### PR TITLE
Dependabot設定を更新

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,29 +1,50 @@
 version: 2
-
-multi-ecosystem-groups:
-  dependency-updates:
-    schedule:
-      interval: "weekly"
-
 updates:
   - package-ecosystem: "npm"
     directory: "/"
-    patterns:
-      - "*"
-    multi-ecosystem-group: "dependency-updates"
+    schedule:
+      interval: "weekly"
     cooldown:
-      default-days: 2
+      default-days: 7
+      semver-major-days: 60
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     groups:
       all-npm-security-updates:
         applies-to: "security-updates"
         patterns:
           - "*"
 
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+    groups:
+      all-github-actions-security-updates:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+
   - package-ecosystem: "docker"
     directory: "/"
-    patterns:
-      - "*"
-    multi-ecosystem-group: "dependency-updates"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+      semver-major-days: 60
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     groups:
       all-docker-security-updates:
         applies-to: "security-updates"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,7 +39,6 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
-      semver-major-days: 60
     ignore:
       - dependency-name: "*"
         update-types:


### PR DESCRIPTION
### Motivation
- 参照先のDependabot設定に合わせてnpm/Dockerの更新ポリシーを整理し、GitHub Actionsも依存更新の監視対象に追加するため。 
- minor/patchの通常更新は自動PRを減らすため無視し、セキュリティアップデートのみ明示的に扱うため。 
- Go関連の設定はこのリポジトリでは不要のため追加していません。

### Description
- `.github/dependabot.yml`を更新して`npm`のスケジュールを週次に設定し`cooldown`を`default-days: 7`および`semver-major-days: 60`に変更しました。 
- `version-update:semver-minor`と`version-update:semver-patch`を無視する設定を追加し、npmとdockerでセキュリティアップデート用のグループを残しました。 
- `github-actions`を監視対象として追加し同様に週次スケジュールとminor/patch無視、セキュリティグループを設定しました。 
- 既存のDocker向け設定は同方針で整理して維持しました。

### Testing
- `ruby -e 'require "yaml"; data = YAML.load_file(".github/dependabot.yml"); abort unless data["version"] == 2 && data["updates"].is_a?(Array); puts "ok"'`は成功しました。 
- `git diff --check`は成功しました。 
- `python`での`yaml`チェックは環境に`yaml`モジュールがなく失敗しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b1eb22ec08326857c64fcfb71fe93)